### PR TITLE
Improvements for Pharo 7

### DIFF
--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addButtonsToTestPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addButtonsToTestPage..st
@@ -1,6 +1,6 @@
-initialize-release
+initialization
 addButtonsToTestPage: aTestPage
-	| aParserButton aParserInspectButton aParserExploreButton |
+	| aParserButton aParserInspectButton aParserDebugButton |
 	aParserButton := PluggableButtonMorph
 		on: self
 		getState: nil
@@ -17,11 +17,11 @@ addButtonsToTestPage: aTestPage
 		hResizing: #spaceFill;
 		vResizing: #shrinkWrap;
 		label: 'Parse and inspect'.
-	aParserExploreButton := PluggableButtonMorph
+	aParserDebugButton := PluggableButtonMorph
 		on: self
 		getState: nil
 		action: #parseInDebug.
-	aParserExploreButton
+	aParserDebugButton
 		hResizing: #spaceFill;
 		vResizing: #shrinkWrap;
 		label: 'Parse in debug'.
@@ -33,5 +33,5 @@ addButtonsToTestPage: aTestPage
 				layoutInset: 0;
 				addMorph: aParserButton;
 				addMorph: aParserInspectButton;
-				addMorph: aParserExploreButton;
+				addMorph: aParserDebugButton;
 				yourself)

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addClassSelectorsToCompilePage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addClassSelectorsToCompilePage..st
@@ -1,8 +1,8 @@
-initialize-release
+initialization
 addClassSelectorsToCompilePage: aCompilePage
 	"The scanner class hasn't got the same meaning as before, since the definition is for both scanner and parser at the same time. Left it for now, since it allows the reuse of a scanner class later on."
 
-	| paLine packageButton scannerClassButton parserClassButton |
+	| paLine |
 	paLine := AlignmentMorph newRow
 		color: Color transparent;
 		vResizing: #shrinkWrap.

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addCompileButtonsToCompilePage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addCompileButtonsToCompilePage..st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 addCompileButtonsToCompilePage: aCompilePage
 	aCompilePage
 		addMorph:

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addConflictsBoxToDefinitionPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addConflictsBoxToDefinitionPage..st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 addConflictsBoxToDefinitionPage: aDefinitionPageTabPalette
 	self
 		conflictTextMorph:

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addItemsBoxToDefinitionPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addItemsBoxToDefinitionPage..st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 addItemsBoxToDefinitionPage: aDefinitionPageTabPalette
 	self
 		itemsTextMorph:

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addSymbolsBoxToDefinitionPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addSymbolsBoxToDefinitionPage..st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 addSymbolsBoxToDefinitionPage: aDefinitionPageTabPalette
 	self
 		symbolsTextMorph:

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTabToDefinitionPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTabToDefinitionPage..st
@@ -1,9 +1,11 @@
-initialize-release
+initialization
 addTabToDefinitionPage: aDefinitionPage
 	self tabList: (self theme newTabGroupIn: World for: #()).
 	aDefinitionPage
 		addMorph: self tabList
-		fullFrame: (LayoutFrame fractions: (0 @ 0.7 corner: 1 @ 1) offsets: (0 @ 4 corner: 0 @ 0)).
+		fullFrame: (LayoutFrame new
+							topFraction: 0.7 offset: 0;
+							bottomFraction: 1 offset: 4).
 	self
 		addConflictsBoxToDefinitionPage: self tabList;
 		addItemsBoxToDefinitionPage: self tabList;

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTestPageToDefinitionPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTestPageToDefinitionPage..st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 addTestPageToDefinitionPage: aDefinitionPagePalette
 	| aTestPage |
 	aTestPage := AlignmentMorph newColumn

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTextToDefinitionPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTextToDefinitionPage..st
@@ -1,11 +1,8 @@
-initialize-release
+initialization
 addTextToDefinitionPage: aDefinitionPage
 	definitionCodeHolder := SmaCCCodeHolder
 		owner: self
 		ownerAcceptSelector: #acceptDefinition:notifying:.
 	aDefinitionPage
 		addMorph: definitionCodeHolder contentsMorph
-		fullFrame:
-			(LayoutFrame
-				fractions: (0 @ 0.0 corner: 1 @ 0.7)
-				offsets: (0 @ 0 corner: 0 @ 0))
+		fullFrame: (LayoutFrame new bottomFraction: 0.7)

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTextToTestPage..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/addTextToTestPage..st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 addTextToTestPage: aTestPage
 	| aTestText |
 	testCodeHolder := SmaCCCodeHolder

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/buildPackageMorph.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/buildPackageMorph.st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 buildPackageMorph
 	^ packageMorph := (EditableDropListMorph
 		on: self

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/buildParserClassMorph.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/buildParserClassMorph.st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 buildParserClassMorph
 	^ parserClassMorph := (EditableDropListMorph
 		on: self

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/buildScannerClassMorph.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/buildScannerClassMorph.st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 buildScannerClassMorph
 	^ scannerClassMorph := (EditableDropListMorph
 		on: self

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/createDefinitionPage.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/createDefinitionPage.st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 createDefinitionPage
 	| aDefinitionPage group |
 	aDefinitionPage := PanelMorph new
@@ -22,7 +22,9 @@ createDefinitionPage
 	group
 		addMorph:
 			(ProportionalSplitterMorph new
-				layoutFrame: (LayoutFrame fractions: (0.0 @ 0.7 corner: 1 @ 0.7) offsets: (0 @ 0 corner: 0 @ 4));
+				layoutFrame: (LayoutFrame new
+						topFraction: 0.7 offset: 0;
+						bottomFraction: 0.7 offset: 4);
 				addLeftOrTop: group submorphs first;
 				addRightOrBottom: group submorphs last;
 				beSplitsTopAndBottom).

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/createTestPage.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/createTestPage.st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 createTestPage
 	| aTestPage |
 	aTestPage := AlignmentMorph newColumn

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/defaultBackgroundColor.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/defaultBackgroundColor.st
@@ -1,0 +1,3 @@
+colors
+defaultBackgroundColor
+	^ UITheme current backgroundColor

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/initialize.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/initialize.st
@@ -1,4 +1,4 @@
-initialize-release
+initialization
 initialize
 	mainWindow := StandardWindow new.
 	mainWindow model: self.

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/openInWorld.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/openInWorld.st
@@ -1,3 +1,3 @@
-initialize-release
+display
 openInWorld
 	self mainWindow openInWorld

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/parseAndEvaluate..st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/parseAndEvaluate..st
@@ -14,7 +14,7 @@ parseAndEvaluate: aBlock
 					aBlock
 						value:
 							(class
-								parse: self testText
+								parse: self testText asString 
 								onError: [ :aString :position | 
 									self displayError: aString at: position notifying: self testCodeHolder contentsMorph.
 									self testCodeHolder contentsMorph hasUnacceptedEdits: true.

--- a/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/parseNoErrorHandling.st
+++ b/SmaCC-Development-UI.package/SmaCCDevelopmentUI.class/instance/parseNoErrorHandling.st
@@ -8,5 +8,5 @@ parseNoErrorHandling
 		ifTrue: [ UIManager default inform: 'No parser defined'.
 			^ false ]
 		ifFalse:
-			[ Cursor wait showWhile: [ class parse: self testText ] ].
+			[ Cursor wait showWhile: [ class parse: self testText asString ] ].
 	^ true

--- a/SmaCC-Development.package/SmaCCIntegerSet.class/README.md
+++ b/SmaCC-Development.package/SmaCCIntegerSet.class/README.md
@@ -1,0 +1,32 @@
+I represent a (possibly large) set of Integers
+
+Responsibilities
+
+My represntation is a sparse bitmap.  I use a collection of n-element byte arrays called "runs", each of which thus contains n * 8 bits.  The value of n is normally self defaultRunSize = 8, so each run contains 256 bits.
+
+That would be great is the maximum value that I am asked to hold is always < 256.  If I'm asked to hold a bigger value, I start to build a tree of 32 runs.  Each tree node holds up to 32 runs; runs with no bits set are not allocated, but are instead represented by 0, which means that every bit in the run can be treated as 0.
+
+Additional levels are added to the tree on demand.  Negative values are accommodated by shifting the whole tree down th enumber line; this is the purpose of the variable start.
+
+Collaborators
+
+I'm used only as the superclass of SmaCCCCharacterSet.
+
+Public API and Key Messages
+
+- add: anInteger
+- remove: anInteger
+- includes: anInteger
+- first       -- answers the minimum element
+- do: aBlock
+
+Instances are created with new and new: size.  The size is ignored.
+ 
+Internal Representation
+
+    Instance Variables
+	data:	0 (if I'm empty), or the top-level array in my tree of data
+	run:		My current run size.  This can change depending on the values that are added
+	start:	The offset below 0 for the whole tree.
+
+This comment was written by Andrew Black, not by the implementor.  They may be wrong; they are certainly incomplete. 

--- a/SmaCC-Development.package/SmaCCIntegerSet.class/properties.json
+++ b/SmaCC-Development.package/SmaCCIntegerSet.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "AndrewBlack 10/13/2017 11:29",
 	"super" : "Collection",
 	"category" : "SmaCC-Development",
 	"classinstvars" : [ ],

--- a/SmaCC-Runtime.package/SmaCCLineNumberStream.class/instance/explore..st
+++ b/SmaCC-Runtime.package/SmaCCLineNumberStream.class/instance/explore..st
@@ -1,0 +1,7 @@
+accessing
+explore: aBlock
+	"evaluate aBlock with this stream as argument.  When done, reset my position to the current position."
+	
+	| savedPosition |
+	savedPosition := self position.
+	[ ^ aBlock value: self ] ensure: [ self position: savedPosition ]

--- a/SmaCC-Runtime.package/SmaCCLineNumberStream.class/instance/lineAndColFor..st
+++ b/SmaCC-Runtime.package/SmaCCLineNumberStream.class/instance/lineAndColFor..st
@@ -1,0 +1,7 @@
+accessing
+lineAndColFor: anIntegerPosition
+	"answers the line and column position as a point."
+	| ln col |
+	ln := self lineNumberFor: anIntegerPosition.
+	col := anIntegerPosition - (eolPositions at: ln) + 1.
+	^ ln @ col

--- a/SmaCC-Runtime.package/SmaCCLineNumberStream.class/instance/printOn..st
+++ b/SmaCC-Runtime.package/SmaCCLineNumberStream.class/instance/printOn..st
@@ -1,0 +1,13 @@
+printing
+printOn: aStream
+	| contents |
+	(sourceStream collectionSpecies isKindOf: String class)
+		ifFalse: [ ^ super printOn: aStream ].
+	contents := sourceStream contents.
+	aStream
+		nextPutAll: self className;
+		nextPutAll: ' "';
+		nextPutAll: (contents copyFrom: 1 to: sourceStream position);
+		nextPutAll: '·';
+		nextPutAll: (contents copyFrom: sourceStream position + 1 to: contents size);
+		nextPutAll: '"'

--- a/SmaCC-Runtime.package/SmaCCParserError.class/instance/description.st
+++ b/SmaCC-Runtime.package/SmaCCParserError.class/instance/description.st
@@ -1,0 +1,9 @@
+accessing
+description
+	"Return a textual description of the exception."
+
+	^ String streamContents: [ :stream | | mt |
+		(mt := self messageText) isEmptyOrNil
+			ifTrue: [ stream << self class name ]
+			ifFalse: [ stream << mt ] 
+	]

--- a/SmaCC-Runtime.package/SmaCCToken.class/README.md
+++ b/SmaCC-Runtime.package/SmaCCToken.class/README.md
@@ -1,7 +1,7 @@
 SmaCCTokens are used as the interface objects between scanner and parser. They hold the string that was scanned and its position information. Also, included in the token is its id. The id specifies what type of token it is.
 
 Instance Variables:
-	id	<Array of: Integer>	the list of possible token types this represents. There can be overlapping tokens, so we list all of the id here. The default parser only looks at the first id, but we can redefine this behavior in a subclass to look at all possibilities until we find a valid token.
+	id	<Array of: Integer>	the list of possible token types this represents. There can be overlapping tokens, so we list all of the ids here. The default parser looks at only the first id, but we can redefine this behavior in a subclass to look at all possibilities until we find a valid token.
 	start	<Integer>	the starting position of the token in the original input
 	value	<Object>	the value of our token (normally a string, but could be anything)
 

--- a/SmaCC-Runtime.package/SmaCCToken.class/properties.json
+++ b/SmaCC-Runtime.package/SmaCCToken.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "<historical>",
+	"commentStamp" : "AndrewBlack 10/12/2017 10:41",
 	"super" : "Object",
 	"category" : "SmaCC-Runtime",
 	"classinstvars" : [ ],


### PR DESCRIPTION
Here are some (not closely related) changes, some of which are needed for Pharo 7.

Adding the missing defaultBackgroundColor method and removing the sends of layout message that are deprecated in Pharo 7 are essential to get SmaCC to even open.

Extracting the String form the Text provided by the UI means that the stream contents is presented as a String in th debugger, rather than as an array of characters, which makes it much more readable.

To aid in debugging streams, SmaCCLineNumberStream is enhanced with a printOn: method that shows the current position, and a method that returns the line & column of a position (as a Point). 