### PR TITLE
Adds missing space before closing paren in a group.

### DIFF
--- a/SmaCC-Development.package/SmaCCGrammar.class/instance/makeGroupFor..st
+++ b/SmaCC-Development.package/SmaCCGrammar.class/instance/makeGroupFor..st
@@ -2,7 +2,7 @@ accessing
 makeGroupFor: aSmaCCRHSCollection
 	| symbol name |
 	name := aSmaCCRHSCollection inject: '' into: [ :sum :each | sum , ' ' , each printString ].
-	symbol := self nonTerminalSymbolNamed: '(' , name, ')'.
+	symbol := self nonTerminalSymbolNamed: '(' , name , ' )'.
 	symbol isEmpty
 		ifTrue: [ 
 			(aSmaCCRHSCollection allSatisfy: [ :each | each size = 1 ])


### PR DESCRIPTION
This is a trivial change to improve the way that groups are printed.  Because `name` starts with a space, the printed text had a space after the open paren, but none before the closing paren.

This commit ensures that there is a space in both places.